### PR TITLE
Use an `std::filesystem` polyfill like that for `std::fmt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
             -DSOURCE_REF=${{github.sha}} `
             -DCMAKE_BUILD_TYPE=${{matrix.build-type}} `
             -DCMAKE_OSX_ARCHITECTURES=${{matrix.arch}} `
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 `
             "-DCMAKE_INSTALL_PREFIX=${{runner.temp}}/install"
         shell: pwsh
       - name: Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             -DSOURCE_REF=${{github.sha}} `
             -DCMAKE_BUILD_TYPE=${{matrix.build-type}} `
             -DCMAKE_OSX_ARCHITECTURES=${{matrix.arch}} `
-            -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 `
+            "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14" `
             "-DCMAKE_INSTALL_PREFIX=${{runner.temp}}/install"
         shell: pwsh
       - name: Compile

--- a/StreamDeckSDK/CMakeLists.txt
+++ b/StreamDeckSDK/CMakeLists.txt
@@ -2,6 +2,7 @@ set(
   SOURCES
   ESDAction.cpp
   ESDConnectionManager.cpp
+  ESDFilesystem.cpp
   ESDUtilities.cpp
   ESDLogger.cpp
   ESDLocalizer.cpp
@@ -29,6 +30,11 @@ target_link_libraries(
   json
   websocketpp
 )
+if (HAS_STD_FILESYSTEM)
+  target_compile_definitions(StreamDeckSDK PUBLIC ESD_HAS_STD_FILESYSTEM)
+else()
+  target_link_libraries(StreamDeckSDK PUBLIC ghc_filesystem)
+endif()
 if (NOT MSVC)
   target_link_libraries(StreamDeckSDK PUBLIC fmt)
 endif()

--- a/StreamDeckSDK/CMakeLists.txt
+++ b/StreamDeckSDK/CMakeLists.txt
@@ -30,7 +30,11 @@ target_link_libraries(
   json
   websocketpp
 )
-if (HAS_STD_FILESYSTEM)
+
+# ghc::filesystem only supports UTF-8 locales, which is not common on Windows.
+# In lieu of all callers properly using UTF-8 locales, we just require
+# std::filesystem.
+if ((NOT WIN32) AND HAS_STD_FILESYSTEM)
   target_compile_definitions(StreamDeckSDK PUBLIC ESD_HAS_STD_FILESYSTEM)
 else()
   target_link_libraries(StreamDeckSDK PUBLIC ghc_filesystem)

--- a/StreamDeckSDK/ESDFilesystem.cpp
+++ b/StreamDeckSDK/ESDFilesystem.cpp
@@ -1,0 +1,7 @@
+// @copyright  (c) 2022, Frederick Emmott
+// This source code is licensed under the MIT-style license found in
+// the LICENSE file.
+
+#ifndef ESD_HAS_STD_FILESYSTEM
+#include <ghc/fs_impl.hpp>
+#endif

--- a/StreamDeckSDK/ESDFilesystem.h
+++ b/StreamDeckSDK/ESDFilesystem.h
@@ -1,0 +1,28 @@
+// @copyright  (c) 2022, Frederick Emmott
+// This source code is licensed under the MIT-style license found in
+// the LICENSE file.
+#pragma once
+
+/* Use std::filesystem where available, ghc::filesystem otherwise. */
+
+#ifdef ESD_HAS_STD_FILESYSTEM
+#include <filesystem>
+namespace ESD {
+  namespace filesystem {
+    using namespace std::filesystem;
+  }
+  using ifstream = std::ifstream;
+  using ofstream = std::ofstream;
+  using fstream = std::fstream;
+}
+#else
+#include <ghc/fs_fwd.hpp>
+namespace ESD {
+  namespace filesystem {
+    using namespace ghc::filesystem;
+  }
+  using ifstream = ghc::filesystem::ifstream;
+  using ofstream = ghc::filesystem::ofstream;
+  using fstream = ghc::filesystem::fstream;
+}
+#endif

--- a/StreamDeckSDK/ESDUtilities.cpp
+++ b/StreamDeckSDK/ESDUtilities.cpp
@@ -4,8 +4,8 @@
 
 #include "ESDUtilities.h"
 
-std::filesystem::path ESDUtilities::GetPluginDirectoryPath() {
-  static std::filesystem::path sPath;
+ESD::filesystem::path ESDUtilities::GetPluginDirectoryPath() {
+  static ESD::filesystem::path sPath;
   if (!sPath.empty()) {
     return {};
   }

--- a/StreamDeckSDK/ESDUtilities.h
+++ b/StreamDeckSDK/ESDUtilities.h
@@ -13,21 +13,22 @@ LICENSE file.
 
 #pragma once
 
-#include <filesystem>
 #include <string>
+
+#include "ESDFilesystem.h"
 
 class ESDUtilities {
  public:
   // Get the path of the .sdPlugin bundle
-  static std::filesystem::path GetPluginDirectoryPath();
+  static ESD::filesystem::path GetPluginDirectoryPath();
   // Get the path of the full executable
-  static std::filesystem::path GetPluginExecutablePath();
+  static ESD::filesystem::path GetPluginExecutablePath();
 
   [[deprecated("use std::this_thread::sleep_for() instead")]]
   static void DoSleep(int inMilliseconds);
 
   // Return a path with the appending path component
-  [[deprecated("Use std::filesystem::path instead")]] static std::string
+  [[deprecated("Use ESD::filesystem::path instead")]] static std::string
   AddPathComponent(
     const std::string &inPath,
     const std::string &inComponentToAdd);
@@ -35,10 +36,10 @@ class ESDUtilities {
   // Return the path without the last component (dirname). Returns path if it is
   // already a root folder (i.e. 'C:\\', '\\ABC' or '/'). Return an empty string
   // if error
-  [[deprecated("Use std::filesystem::path instead")]] static std::string
+  [[deprecated("Use ESD::filesystem::path instead")]] static std::string
   GetParentDirectoryPath(const std::string &inPath);
 
   // Return the last component of the path (basename)
-  [[deprecated("Use std::filesystem::path instead")]] static std::string
+  [[deprecated("Use ESD::filesystem::path instead")]] static std::string
   GetFileName(const std::string &inPath);
 };

--- a/StreamDeckSDK/ESDUtilitiesLinux.cpp
+++ b/StreamDeckSDK/ESDUtilitiesLinux.cpp
@@ -7,8 +7,8 @@
 #include <unistd.h>
 #include <cassert>
 
-std::filesystem::path ESDUtilities::GetPluginExecutablePath() {
-  static std::filesystem::path sPath;
+ESD::filesystem::path ESDUtilities::GetPluginExecutablePath() {
+  static ESD::filesystem::path sPath;
   if (!sPath.empty()) {
     return sPath;
   }

--- a/StreamDeckSDK/ESDUtilitiesMac.cpp
+++ b/StreamDeckSDK/ESDUtilitiesMac.cpp
@@ -15,8 +15,8 @@ LICENSE file.
 
 #include <mach-o/dyld.h>
 
-std::filesystem::path ESDUtilities::GetPluginExecutablePath() {
-  static std::filesystem::path sPath;
+ESD::filesystem::path ESDUtilities::GetPluginExecutablePath() {
+  static ESD::filesystem::path sPath;
   if (!sPath.empty()) {
     return sPath;
   }

--- a/StreamDeckSDK/ESDUtilitiesWindows.cpp
+++ b/StreamDeckSDK/ESDUtilitiesWindows.cpp
@@ -148,8 +148,8 @@ std::string ESDUtilities::GetParentDirectoryPath(const std::string& inPath) {
 }
 
 
-std::filesystem::path ESDUtilities::GetPluginExecutablePath() {
-  static std::filesystem::path sPath;
+ESD::filesystem::path ESDUtilities::GetPluginExecutablePath() {
+  static ESD::filesystem::path sPath;
   if (!sPath.empty()) {
     return sPath;
   }

--- a/Vendor/CMakeLists.txt
+++ b/Vendor/CMakeLists.txt
@@ -3,6 +3,7 @@ include(ExternalProject)
 include(asio.cmake)
 include(json.cmake)
 include(websocketpp.cmake)
+include(filesystem.cmake)
 
 # TODO: remove on other platforms too when they have adequate std::format support
 if (NOT MSVC)

--- a/Vendor/filesystem.cmake
+++ b/Vendor/filesystem.cmake
@@ -1,0 +1,27 @@
+include(FetchContent)
+include(CheckCXXSourceCompiles)
+
+check_cxx_source_compiles("
+#ifdef __APPLE__
+#include <Availability.h> // for deployment target to support pre-catalina targets without std::fs
+#endif
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || (defined(__cplusplus) && __cplusplus >= 201703L)) && defined(__has_include)
+#if __has_include(<filesystem>) && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500)
+#define GHC_USE_STD_FS
+#endif
+#endif
+#ifndef GHC_USE_STD_FS
+#error \"std::filesystem missing or unusable\"
+#endif
+" HAS_STD_FILESYSTEM)
+
+if(NOT HAS_STD_FILESYSTEM)
+  FetchContent_Declare(
+    filesystem
+    URL https://github.com/gulrak/filesystem/archive/refs/tags/v1.5.12.zip
+    URL_HASH SHA256=c11303d75ad56dca1f7273ab95cbf7e7380c4448362a4d4e63156814caf0a713
+    EXCLUDE_FROM_ALL
+  )
+
+  FetchContent_MakeAvailable(filesystem)
+endif()


### PR DESCRIPTION
This restores support for macOS 10.14 (and probably earlier, but I can only test 10.14).

This uses `ghc_filesystem`, which is a single-header polyfill for `std::filesystem`.