### PR TITLE
Added missing header

### DIFF
--- a/StreamDeckSDK/ESDUtilitiesMac.cpp
+++ b/StreamDeckSDK/ESDUtilitiesMac.cpp
@@ -14,6 +14,7 @@ LICENSE file.
 #include "ESDUtilities.h"
 
 #include <mach-o/dyld.h>
+#include <cassert>
 
 ESD::filesystem::path ESDUtilities::GetPluginExecutablePath() {
   static ESD::filesystem::path sPath;


### PR DESCRIPTION
Without including \<cassert\>, compilation will fail on recent versions of macOS