### PR TITLE
Support images other than PNG

### DIFF
--- a/StreamDeckSDK/ESDConnectionManager.cpp
+++ b/StreamDeckSDK/ESDConnectionManager.cpp
@@ -232,14 +232,15 @@ void ESDConnectionManager::SetImage(
 
   json payload;
   payload[kESDSDKPayloadTarget] = inTarget;
-  const std::string prefix = "data:image/png;base64,";
+  const std::string pngPrefix = "data:image/png;base64,";
+  const std::string prefix = "data:image/";
   if (
     inBase64ImageString.empty()
     || inBase64ImageString.substr(0, prefix.length()).find(prefix) == 0)
     payload[kESDSDKPayloadImage] = inBase64ImageString;
   else
-    payload[kESDSDKPayloadImage]
-      = "data:image/png;base64," + inBase64ImageString;
+    // assume Base64-encoded PNG image
+    payload[kESDSDKPayloadImage] = pngPrefix + inBase64ImageString;
   if (inState >= 0) {
     payload[kESDSDKPayloadState] = inState;
   }


### PR DESCRIPTION
Elgato supports various image types besides PNG. It might be base64-encoded binary content for any MIME type (BMP and JPEG included). Or even, XML for SVG.

See [documentation](https://docs.elgato.com/sdk/plugins/events-sent#setimage) for the details.

This pull requests removes assumption that every payload should be prefixed with `data:image/png;base64,`. It keeps appending that string if no MIME type is given (for possible backward compatibility), but also relaxes prefix requirement to be just `data:image/` in which case it leaves string as is.